### PR TITLE
Convert connector from .hbs to .gjs format

### DIFF
--- a/javascripts/discourse/connectors/composer-after-save-or-cancel/composer-after-save-or-cancel.gjs
+++ b/javascripts/discourse/connectors/composer-after-save-or-cancel/composer-after-save-or-cancel.gjs
@@ -1,5 +1,3 @@
 import ComposerLinkGenerator from "../../components/composer-link-generator";
 
-<template>
-  <ComposerLinkGenerator @model={{@outletArgs.model}} />
-</template>
+<template><ComposerLinkGenerator @model={{@outletArgs.model}} /></template>

--- a/javascripts/discourse/connectors/composer-after-save-or-cancel/composer-after-save-or-cancel.gjs
+++ b/javascripts/discourse/connectors/composer-after-save-or-cancel/composer-after-save-or-cancel.gjs
@@ -1,0 +1,5 @@
+import ComposerLinkGenerator from "../../components/composer-link-generator";
+
+<template>
+  <ComposerLinkGenerator @model={{@outletArgs.model}} />
+</template>

--- a/javascripts/discourse/connectors/composer-after-save-or-cancel/composer-after-save-or-cancel.hbs
+++ b/javascripts/discourse/connectors/composer-after-save-or-cancel/composer-after-save-or-cancel.hbs
@@ -1,1 +1,0 @@
-<ComposerLinkGenerator @model={{this.model}} />


### PR DESCRIPTION
## Summary

- Converts `composer-after-save-or-cancel.hbs` to `composer-after-save-or-cancel.gjs`
- Updates outlet args reference from `this.model` to `@outletArgs.model`
- Resolves the deprecation notice: *"The file uses the deprecated .hbs extension. Refactor it to use '.gjs' instead."* ([discourse.hbs-extension](https://meta.discourse.org/t/deprecating-hbs-file-extension-in-themes-and-plugins/398896))

## Test plan

- [ ] Verify the composer link generator button still appears correctly in the composer
- [ ] Confirm no deprecation warnings appear in the browser console

Generated with AI

Co-Authored-By: Claude Code <ai@netwrix.com>