### PR TITLE
FIX: Support tags as objects

### DIFF
--- a/javascripts/discourse/components/composer-link-generator.gjs
+++ b/javascripts/discourse/components/composer-link-generator.gjs
@@ -65,7 +65,13 @@ export default class ComposerLinkGenerator extends Component {
       )}`;
     }
     if (this.model.tags && this.model.tags.length > 0) {
-      const tagsString = this.model.tags.join(",");
+      const tagsString = this.model.tags
+        // Tags were migrated from strings to objects, but I discovered a bug
+        // where it's still a string when you reopen the composer.
+        // The check for string ensures it works in both cases.
+        // Can be removed once fixed. Also helps with backwards compatibility
+        .map((tag) => (typeof tag === "string" ? tag : tag.name))
+        .join(",");
       generatedLink += `&tags=${encodeURIComponent(tagsString)}`;
     }
 


### PR DESCRIPTION
While Discourse now returns tags as objects {id, name, slug, ...}, there is a bug where reopening the composer returns plain strings instead. That's why I support both now. Additionally this ensures backwards compatibility with older Discourse versions. 